### PR TITLE
Add an option to force a constant allocation order.

### DIFF
--- a/src/internal/allocator/mod.rs
+++ b/src/internal/allocator/mod.rs
@@ -427,10 +427,10 @@ impl Allocator {
         while let Some((vreg, stage)) = context.allocator.queue.dequeue() {
             match vreg {
                 VirtRegOrGroup::Reg(vreg) => {
-                    context.allocate(vreg, stage, options.random_allocation_order)?
+                    context.allocate(vreg, stage, options.const_allocation_order)?
                 }
                 VirtRegOrGroup::Group(group) => {
-                    context.allocate(group, stage, options.random_allocation_order)?
+                    context.allocate(group, stage, options.const_allocation_order)?
                 }
             };
         }
@@ -518,7 +518,7 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
         &mut self,
         vreg: impl AbstractVirtRegGroup,
         stage: Stage,
-        random_alloc_order: bool,
+        const_alloc_order: bool,
     ) -> Result<(), RegAllocError> {
         trace!("Allocating {vreg} in stage {stage:?}");
         vreg.dump(self.virt_regs, self.uses);
@@ -537,7 +537,7 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
             self.hints,
             self.reginfo,
             hint,
-            random_alloc_order,
+            const_alloc_order,
         );
         if trace_enabled!() {
             trace!("Allocation order:");

--- a/src/internal/allocator/order.rs
+++ b/src/internal/allocator/order.rs
@@ -92,7 +92,7 @@ impl AllocationOrder {
         hints: &Hints,
         reginfo: &impl RegInfo,
         hint: Option<PhysReg>,
-        random_alloc_order: bool,
+        const_alloc_order: bool,
     ) {
         self.candidates.clear();
         let class = virt_regs[vreg.first_vreg(virt_regs)].class;
@@ -142,15 +142,15 @@ impl AllocationOrder {
         //
         // This is optional as non-random allocation orders may produce
         // better register allocation at the cost of compile time.
-        let random_seed = if random {
+        let random_seed = if const_alloc_order {
+            0
+        } else {
             virt_regs.segments(vreg.first_vreg(virt_regs))[0]
                 .live_range
                 .from
                 .inst()
                 .index()
                 + vreg.first_vreg(virt_regs).index()
-        } else {
-            0
         };
 
         // Add the remaining candidates from the register class's allocation

--- a/src/internal/allocator/order.rs
+++ b/src/internal/allocator/order.rs
@@ -92,6 +92,7 @@ impl AllocationOrder {
         hints: &Hints,
         reginfo: &impl RegInfo,
         hint: Option<PhysReg>,
+        random_alloc_order: bool,
     ) {
         self.candidates.clear();
         let class = virt_regs[vreg.first_vreg(virt_regs)].class;
@@ -138,12 +139,19 @@ impl AllocationOrder {
         // Random seed algorithm copied from regalloc2: this helps spread
         // allocations around and increases the chance that we find a free
         // register on the first try.
-        let random_seed = virt_regs.segments(vreg.first_vreg(virt_regs))[0]
-            .live_range
-            .from
-            .inst()
-            .index()
-            + vreg.first_vreg(virt_regs).index();
+        //
+        // This is optional as non-random allocation orders may produce
+        // better register allocation at the cost of compile time.
+        let random_seed = if random {
+            virt_regs.segments(vreg.first_vreg(virt_regs))[0]
+                .live_range
+                .from
+                .inst()
+                .index()
+                + vreg.first_vreg(virt_regs).index()
+        } else {
+            0
+        };
 
         // Add the remaining candidates from the register class's allocation
         // order.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl RegisterAllocator {
             &mut self.stats,
             func,
             reginfo,
-            options.split_strategy,
+            options,
         )?;
 
         // Allocate spill slots.
@@ -377,6 +377,12 @@ pub struct Options {
     /// Selects the algorithm for live range splitting.
     #[cfg_attr(feature = "clap", clap(long, default_value = "linear"))]
     pub split_strategy: SplitStrategy,
+
+    /// Choose a random allocation order of physical registers when probing
+    /// for a free register. Still respects preferred and non-preferred
+    /// order though.
+    #[cfg_attr(feature = "clap", clap(long, default_value = "true"))]
+    pub random_allocation_order: bool,
 }
 
 /// Error returned by the register allocator if allocation is impossible.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,11 +378,12 @@ pub struct Options {
     #[cfg_attr(feature = "clap", clap(long, default_value = "linear"))]
     pub split_strategy: SplitStrategy,
 
-    /// Choose a random allocation order of physical registers when probing
-    /// for a free register. Still respects preferred and non-preferred
-    /// order though.
-    #[cfg_attr(feature = "clap", clap(long, default_value = "true"))]
-    pub random_allocation_order: bool,
+    /// Forces a constant allocation order, instead of a random one. This
+    /// makes it more likely that regalloc will pick the same register for
+    /// for different non-interferring virtual registers. It may increase
+    /// output code quality at the cost of compile time.
+    #[cfg_attr(feature = "clap", clap(long, default_value = "false"))]
+    pub const_allocation_order: bool,
 }
 
 /// Error returned by the register allocator if allocation is impossible.


### PR DESCRIPTION
I added a new option to the `Options` structure, and plumbed it's use throughout RA3. 

I changed to passing the entire `Options` struct to `Allocator::run` now because it uses both the `split_strategy` and `const_allocation_order` members.