### PR TITLE
Remove a couple of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ bitflags = "2.4.2"
 hashbrown = "0.15.2"
 smallvec = { version = "1.11.2", features = ["union"] }
 log = { version = "0.4.20", default-features = false }
-ordered-float = { version = "5.0.0", default-features = false }
 pest = { version = "2.7.5", optional = true }
 pest_derive = { version = "2.7.5", optional = true, default-features = false }
 rustc-hash = { version = "2.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [".github"]
 [dependencies]
 anyhow = { version = "1.0.75", default-features = false }
 arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
-hashbrown = { version = "0.15.2", default-features = false }
+hashbrown = { version = "0.15.2", default-features = false, features = ["inline-more"] }
 smallvec = { version = "1.11.2", features = ["union"] }
 log = { version = "0.4.20", default-features = false }
 pest = { version = "2.7.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".github"]
 anyhow = { version = "1.0.75", default-features = false }
 arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
 bitflags = "2.4.2"
-hashbrown = "0.15.2"
+hashbrown = { version = "0.15.2", default-features = false }
 smallvec = { version = "1.11.2", features = ["union"] }
 log = { version = "0.4.20", default-features = false }
 pest = { version = "2.7.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ exclude = [".github"]
 [dependencies]
 anyhow = { version = "1.0.75", default-features = false }
 arbitrary = { version = "1.3.2", optional = true, features = ["derive"] }
-bitflags = "2.4.2"
 hashbrown = { version = "0.15.2", default-features = false }
 smallvec = { version = "1.11.2", features = ["union"] }
 log = { version = "0.4.20", default-features = false }


### PR DESCRIPTION
With this the only extra dependencies that regalloc3 pulls in that Cranelift doesn't already depend on are brie-tree and through it allocator-api2 and nonmax.