### PR TITLE
Fix blockparams being used on the first instruction of a block

### DIFF
--- a/src/debug_utils/checker.rs
+++ b/src/debug_utils/checker.rs
@@ -663,7 +663,10 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
             OperandKind::Def(value) | OperandKind::EarlyDef(value) => {
                 self.state.remove_value(value);
                 for unit in alloc.units(reginfo) {
-                    ensure!(!self.def_units.contains(unit), "Conflicting def on {unit}");
+                    ensure!(
+                        !self.def_units.contains(unit),
+                        "{inst}: Conflicting def on {unit}"
+                    );
                     self.def_units.insert(unit);
                     self.state.set_value(unit, value);
                 }
@@ -675,7 +678,7 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
                 for unit in alloc.units(reginfo) {
                     ensure!(
                         self.state.unit_contains(unit, value),
-                        "{unit} in {alloc} does not contain {value}"
+                        "{inst}: {unit} in {alloc} does not contain {value}"
                     );
                 }
             }
@@ -700,7 +703,10 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
                 {
                     self.state.remove_value(value);
                     for unit in Allocation::reg(reg).units(reginfo) {
-                        ensure!(!self.def_units.contains(unit), "Conflicting def on {unit}");
+                        ensure!(
+                            !self.def_units.contains(unit),
+                            "{inst}: Conflicting def on {unit}"
+                        );
                         self.def_units.insert(unit);
                         self.state.set_value(unit, value);
                     }
@@ -719,7 +725,7 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
                     for unit in Allocation::reg(reg).units(reginfo) {
                         ensure!(
                             self.state.unit_contains(unit, value),
-                            "{unit} in {reg} does not contain {value}"
+                            "{inst}: {unit} in {reg} does not contain {value}"
                         );
                     }
                 }

--- a/src/debug_utils/generic_function/arbitrary.rs
+++ b/src/debug_utils/generic_function/arbitrary.rs
@@ -347,28 +347,23 @@ impl<'a, 'b, R: RegInfo> FunctionBuilder<'a, 'b, R> {
     fn gen_block_insts(&mut self, block: Block) -> Result<()> {
         // We generate instructions in reverse, starting with the terminator.
         // This allows us to know exactly what values need to be defined later.
-        let num_insts = self.u.int_in_range(self.config.insts_per_block.clone())?;
+        let mut num_insts = self.u.int_in_range(self.config.insts_per_block.clone())?;
 
-        // Set up outgoing blockparams if we have a single successor.
+        // Set up outgoing blockparams if we have a single successor that itself
+        // has multiple predecessors.
         if let [succ] = self.func.blocks[block].succs[..] {
-            for idx in 0..self.func.blocks[succ].block_params_in.len() {
-                let bank = self.func.values[self.func.blocks[succ].block_params_in[idx]].bank;
-                let first_block_for_def = if num_insts == 0 {
-                    // If this is the entry block then we don't have an
-                    // immediate dominator. We will later be force to emit an
-                    // instruction to define values for the block.
-                    self.domtree.immediate_dominator(block).unwrap_or(block)
-                } else {
-                    block
-                };
-                let value = self.get_value_for_use(bank, first_block_for_def)?;
-                self.func.blocks[block].block_params_out.push(value);
-            }
-
-            // If the successor has more than one predecessor, our terminator
-            // cannot have operands. Create an empty terminator now before
-            // adding any instructions.
             if self.func.blocks[succ].preds.len() > 1 {
+                for idx in 0..self.func.blocks[succ].block_params_in.len() {
+                    let bank = self.func.values[self.func.blocks[succ].block_params_in[idx]].bank;
+                    // It's fine if this adds defs to the current block, we will
+                    // increase num_insts below to ensure these have a defining
+                    // instruction.
+                    let value = self.get_value_for_use(bank, block, false)?;
+                    self.func.blocks[block].block_params_out.push(value);
+                }
+
+                // Our terminator cannot have operands. Create an empty
+                // terminator now before adding any instructions.
                 self.block_insts[block].push(InstData {
                     operands: vec![],
                     clobbers: vec![],
@@ -376,6 +371,13 @@ impl<'a, 'b, R: RegInfo> FunctionBuilder<'a, 'b, R> {
                     terminator_kind: Some(TerminatorKind::Jump),
                     is_pure: false,
                 });
+
+                // If there are values that need to be defined in this block for
+                // outgoing blockparams, make sure it has at least one
+                // instruction.
+                if num_insts == 0 && !self.defs_by_blocks[block].is_empty() {
+                    num_insts = 1;
+                }
             }
         }
 
@@ -400,14 +402,6 @@ impl<'a, 'b, R: RegInfo> FunctionBuilder<'a, 'b, R> {
             // in the block) then we need to ensure all definitions assigned to
             // this block are actually processed.
             let inst = self.gen_inst(block, idx == num_insts - 1, false)?;
-            self.block_insts[block].push(inst);
-        }
-
-        // If this is the entry block and no instructions were generated, we
-        // may need to force an instruction to exist to define any values that
-        // still need to be defined.
-        if num_insts == 0 && !self.defs_by_blocks[block].is_empty() {
-            let inst = self.gen_inst(block, true, false)?;
             self.block_insts[block].push(inst);
         }
 
@@ -437,7 +431,12 @@ impl<'a, 'b, R: RegInfo> FunctionBuilder<'a, 'b, R> {
     /// Because we process instructions in post-order, uses are processed before
     /// definitions. If necessary, this function will create a new value to be
     /// defined as a later point in the current block or in a dominating block.
-    fn get_value_for_use(&mut self, bank: RegBank, first_block_for_def: Block) -> Result<Value> {
+    fn get_value_for_use(
+        &mut self,
+        bank: RegBank,
+        block: Block,
+        is_first_inst: bool,
+    ) -> Result<Value> {
         // Try to reuse an existing value.
         if self.u.arbitrary()? {
             self.use_candidates.clear();
@@ -445,7 +444,7 @@ impl<'a, 'b, R: RegInfo> FunctionBuilder<'a, 'b, R> {
             // Walk up the dominator tree to collect all values that we can use.
             // Specifically: any value whose definition dominates us and which
             // comes from a compatible register bank.
-            let mut reuse_block = first_block_for_def;
+            let mut reuse_block = block;
             loop {
                 self.use_candidates.extend(
                     self.defs_by_blocks[reuse_block]
@@ -468,8 +467,13 @@ impl<'a, 'b, R: RegInfo> FunctionBuilder<'a, 'b, R> {
         }
 
         // Walk up the dominator tree to find a block in which to define this
-        // value.
-        let mut def_block = first_block_for_def;
+        // value. If this is the first instruction then we cannot add a new
+        // definition in the current block.
+        let mut def_block = if is_first_inst {
+            self.domtree.immediate_dominator(block).unwrap()
+        } else {
+            block
+        };
         while let Some(idom) = self.domtree.immediate_dominator(def_block) {
             // This halves the probability every time we go up the tree.
             if self.u.arbitrary()? {
@@ -486,7 +490,12 @@ impl<'a, 'b, R: RegInfo> FunctionBuilder<'a, 'b, R> {
     }
 
     /// Generates an operand which uses a value.
-    fn gen_use(&mut self, first_block_for_def: Block, inst: &mut InstData) -> Result<Operand> {
+    fn gen_use(
+        &mut self,
+        block: Block,
+        is_first_inst: bool,
+        inst: &mut InstData,
+    ) -> Result<Operand> {
         // Generate a NonAllocatable operand if we have non-allocatable registers.
         if !self.non_allocatable_regs.is_empty() && self.u.arbitrary()? {
             let reg = *self.u.choose(&self.non_allocatable_regs)?;
@@ -499,7 +508,7 @@ impl<'a, 'b, R: RegInfo> FunctionBuilder<'a, 'b, R> {
             let bank = RegBank::new(self.u.choose_index(self.reginfo.num_banks())?);
             let reg = *self.u.choose(&self.reg_per_bank[bank])?;
             if self.check_fixed_conflict(reg, true, false) {
-                let value = self.get_value_for_use(bank, first_block_for_def)?;
+                let value = self.get_value_for_use(bank, block, is_first_inst)?;
                 return Ok(Operand::new(
                     OperandKind::Use(value),
                     OperandConstraint::Fixed(reg),
@@ -529,12 +538,12 @@ impl<'a, 'b, R: RegInfo> FunctionBuilder<'a, 'b, R> {
         let kind = if group_size > 1 {
             let mut values = vec![];
             for _ in 0..group_size {
-                values.push(self.get_value_for_use(bank, first_block_for_def)?);
+                values.push(self.get_value_for_use(bank, block, is_first_inst)?);
             }
             let value_group = self.func.value_groups.push(values);
             OperandKind::UseGroup(value_group)
         } else {
-            let value = self.get_value_for_use(bank, first_block_for_def)?;
+            let value = self.get_value_for_use(bank, block, is_first_inst)?;
             OperandKind::Use(value)
         };
         Ok(Operand::new(kind, OperandConstraint::Class(class)))
@@ -645,21 +654,11 @@ impl<'a, 'b, R: RegInfo> FunctionBuilder<'a, 'b, R> {
             }
         }
 
-        // Lowest block in the dominator tree in which values that we use in the
-        // current instruction are going to be defined. If we are emitting the
-        // first instruction of the block that values must come from the
-        // immediate dominator. In the case of the first instruction of the
-        // entry block we cannot add any use operands at all.
-        let first_block_for_def = if is_first_inst {
-            self.domtree.immediate_dominator(block)
-        } else {
-            Some(block)
-        };
-
-        // Add operands which use values.
-        if let Some(first_block_for_def) = first_block_for_def {
+        // Add operands which use values, unless we are the first instruction of
+        // the entry block.
+        if block != Block::ENTRY_BLOCK || !is_first_inst {
             for _ in 0..self.u.int_in_range(self.config.uses_per_inst.clone())? {
-                let op = self.gen_use(first_block_for_def, &mut inst)?;
+                let op = self.gen_use(block, is_first_inst, &mut inst)?;
                 inst.operands.push(op);
             }
         }

--- a/src/internal/move_resolver.rs
+++ b/src/internal/move_resolver.rs
@@ -147,7 +147,7 @@ struct TiedMove {
     def_slot: u16,
     class: RegClass,
     group_index: u8,
-    is_blockparam: bool,
+    blockparam_value: Option<Value>,
 }
 
 #[derive(Debug)]
@@ -276,11 +276,11 @@ impl MoveResolver {
             self.dest_half_moves
                 .push((tied.move_pos, tied.value, def_alloc));
 
-            if tied.is_blockparam {
+            if let Some(value) = tied.blockparam_value {
                 // Record the allocation assigned to the block parameter
                 // for the move optimizer.
                 let block = func.inst_block(tied.inst);
-                self.blockparam_allocs.push((block, tied.value, def_alloc));
+                self.blockparam_allocs.push((block, value, def_alloc));
             }
         }
 
@@ -467,7 +467,7 @@ impl MoveResolver {
                         def_slot,
                         class,
                         group_index,
-                        is_blockparam: false,
+                        blockparam_value: None,
                     });
                 }
 
@@ -895,7 +895,7 @@ impl<F: Function> Context<'_, F> {
                             def_slot,
                             class,
                             group_index,
-                            is_blockparam,
+                            blockparam_value: is_blockparam.then_some(segment.value),
                         });
                     },
                 );

--- a/src/internal/virt_regs/builder.rs
+++ b/src/internal/virt_regs/builder.rs
@@ -19,8 +19,8 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
-use core::array;
 use core::cmp::Ordering;
+use core::{array, mem};
 
 use crate::entity::packed_option::{PackedOption, ReservedValue};
 use crate::entity::{CompactList, SecondaryMap};
@@ -62,7 +62,11 @@ pub struct VirtRegBuilder {
     /// `Use`s that could not be merged into the current virtual register due to
     /// a conflicting `Use` at the same instruction. These must be processed
     /// separately after normal uses are processed.
-    conflicting_uses: Vec<(Value, Use)>,
+    ///
+    /// The last field indicates whether this value is a blockparam defined in
+    /// the current block *and* the conflicting use is on the first instruction
+    /// of that block.
+    conflicting_uses: Vec<(Value, Use, Option<u32>)>,
 }
 
 impl VirtRegBuilder {
@@ -401,7 +405,7 @@ struct Context<'a, F, R> {
     stats: &'a mut Stats,
     options: &'a Options,
     value_group_mapping: &'a mut SecondaryMap<ValueGroup, PackedOption<VirtRegGroup>>,
-    conflicting_uses: &'a mut Vec<(Value, Use)>,
+    conflicting_uses: &'a mut Vec<(Value, Use, Option<u32>)>,
     new_vregs: Option<&'a mut Vec<VirtReg>>,
 
     /// Value set that the virtual register is part of.
@@ -474,7 +478,7 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
                         let end_use_idx = use_list.index(idx);
                         let end_class = self.constraints.class;
                         let end_pos = self.uses[end_use_idx].pos;
-                        let (start_use_idx, start_value) =
+                        let (start_use_idx, start_value, start_seg_idx) =
                             self.find_conflict_start_point(segments, seg_idx, idx);
                         let start_pos = self.uses[start_use_idx].pos;
                         let start_class = self.constraints.class;
@@ -503,18 +507,29 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
                             // The 2 conflicting uses may have different values
                             // if the conflict is from 2 tied operands with
                             // incompatible register classes.
-                            let (conflict_idx, conflict_value) =
+                            let (conflict_idx, conflict_value, conflict_use_list) =
                                 if !self.uses[end_use_idx].kind.is_def() {
-                                    (end_use_idx, value)
+                                    (end_use_idx, value, use_list)
                                 } else {
-                                    (start_use_idx, start_value)
+                                    (start_use_idx, start_value, segments[start_seg_idx].use_list)
                                 };
                             let conflict_use = self.uses[conflict_idx];
                             debug_assert!(!conflict_use.kind.is_def());
 
                             // Remove the `Use` from the segment and split it
                             // off into a separate virtual register.
-                            self.conflicting_uses.push((conflict_value, conflict_use));
+                            let blockparam_idx = match self.uses[conflict_use_list].first() {
+                                Some(&Use {
+                                    pos,
+                                    kind: UseKind::BlockparamIn { blockparam_idx },
+                                }) if pos == start_pos => Some(blockparam_idx),
+                                _ => None,
+                            };
+                            self.conflicting_uses.push((
+                                conflict_value,
+                                conflict_use,
+                                blockparam_idx,
+                            ));
                             self.uses[conflict_idx].kind = UseKind::ConstraintConflict {};
                         } else {
                             // Prefer to align the split close to the use that
@@ -574,13 +589,13 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
         // Iterate over groups of conflicting uses at each instruction. We need
         // to attempt to merge each pair of uses so that group uses at the same
         // index for the same group are assigned to the same vreg.
-        let mut conflicting_uses = core::mem::take(self.conflicting_uses);
+        let mut conflicting_uses = mem::take(self.conflicting_uses);
         for uses in conflicting_uses.chunk_by_mut(|a, b| a.1.pos == b.1.pos) {
             // Conflicts can only happen due to multiple uses of the same value
             // at the same instruction. It's impossible to have conflicts with
-            // multiple values since the values would not have been coalesced >
+            // multiple values since the values would not have been coalesced in
             // that case.
-            let (value, Use { pos, kind: _ }) = uses[0];
+            let (value, Use { pos, kind: _ }, blockparam_idx) = uses[0];
             debug_assert!(uses.iter().all(|&u| u.0 == value));
 
             trace!("Processing conflicting uses of {value} at {pos}");
@@ -612,11 +627,26 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
                     }
                 }
 
-                // Add an implicit live-in to the new segment.
-                let mut use_list = self
-                    .uses
-                    .add_use_list(uses[vreg_start..vreg_end].iter().map(|&(_value, u)| u));
-                use_list.set_livein(true);
+                // If the conflict happened on the first instruction of a block
+                // and the conflicting value is an incoming blockparam then we
+                // need to insert a UseKind::BlockparamIn before it. Otherwise
+                // just mark the segment as being live-in.
+                let mut use_list = self.uses.add_use_list(
+                    blockparam_idx
+                        .map(|blockparam_idx| Use {
+                            pos,
+                            kind: UseKind::BlockparamIn { blockparam_idx },
+                        })
+                        .into_iter()
+                        .chain(
+                            uses[vreg_start..vreg_end]
+                                .iter()
+                                .map(|&(_value, u, _blockparam_idx)| u),
+                        ),
+                );
+                if blockparam_idx.is_none() {
+                    use_list.set_livein(true);
+                }
 
                 // Emit a vreg with the uses we managed to merge.
                 let conflict_segment = ValueSegment {
@@ -648,7 +678,7 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
         segments: &[ValueSegment],
         end_seg_idx: usize,
         end_idx: usize,
-    ) -> (UseIndex, Value) {
+    ) -> (UseIndex, Value, usize) {
         trace!("Finding conflict start point...");
         let mut constraints = VirtRegBuilderConstraints::new(self.top_level_class);
 
@@ -663,7 +693,11 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
                 self.func,
                 self.reginfo,
             ) {
-                return (use_list.index(idx), segments[end_seg_idx].value);
+                return (
+                    use_list.index(idx),
+                    segments[end_seg_idx].value,
+                    end_seg_idx,
+                );
             }
         }
 
@@ -678,7 +712,7 @@ impl<F: Function, R: RegInfo> Context<'_, F, R> {
                     self.func,
                     self.reginfo,
                 ) {
-                    return (idx, segments[seg_idx].value);
+                    return (idx, segments[seg_idx].value, seg_idx);
                 }
             }
         }


### PR DESCRIPTION
Previously the random function generator would not use any values defined in the current block in the first instruction of that block, which unfortunately resulted in some edge case bugs not being caught.